### PR TITLE
Add a Pre-Transition Signal

### DIFF
--- a/addons/transitions/Transitions.gd
+++ b/addons/transitions/Transitions.gd
@@ -1,5 +1,7 @@
 extends CanvasLayer
 
+signal pre_transition
+
 const FadeScene = preload("res://addons/transitions/FadeScene.tscn")
 var _root:Viewport
 var _current_scene = null
@@ -25,6 +27,7 @@ func change_scene(new_scene:Node2D, fade_type, fade_time_seconds:float, shader_i
 	
 	var data = _common_pre_fade(fade_type, fade_time_seconds, shader_image)
 	_set_scene(new_scene)
+	emit_signal("pre_transition")
 	
 	var coroutine = _common_wait_for_fade(data, fade_type, fade_time_seconds)
 	yield(coroutine, "completed")


### PR DESCRIPTION
This allows for the code calling `Transitions.change_scene(...)` to connect to the signal and perform some setup or modifications to the scene before the transition starts.

Example Usage:
```gdscript
func setup_player():
    pass # Player setup here. Set its position, change its colour, whatever!

func transition_scene(next_scene_path: String):
    var next_scene = load(next_scene_path).instance()
    Transitions.connect("pre_transition", self, "setup_player")
    Transitions.change_scene(next_scene, Transitions.FadeType.Blend, 1.5, transition)
    # Optional disconnecting from signal here.
```

Very minimal change. Might be my Godot Newbie Naïvety, but I can't imagine how these two lines could break anything.
Also open to different naming of the signal and/or passing the new scene along with it.