### PR TITLE
Custom scene container

### DIFF
--- a/addons/transitions/Transitions.gd
+++ b/addons/transitions/Transitions.gd
@@ -13,7 +13,9 @@ enum FadeType {
 	Blend
 }
 
-func _set_scene_container(new_container):
+func _set_scene_container(new_container:Node):
+	if new_container == null:
+		push_error("")
 	# Allow users to specify their own scene container node.
 	# This method also sets the current scene to be the last child of the new container.
 	scene_container = new_container

--- a/addons/transitions/Transitions.gd
+++ b/addons/transitions/Transitions.gd
@@ -15,7 +15,7 @@ enum FadeType {
 
 func _set_scene_container(new_container:Node):
 	if new_container == null:
-		push_error("")
+		push_error("Can't change scene container to null scene!")
 	# Allow users to specify their own scene container node.
 	# This method also sets the current scene to be the last child of the new container.
 	scene_container = new_container

--- a/addons/transitions/Transitions.gd
+++ b/addons/transitions/Transitions.gd
@@ -5,6 +5,7 @@ signal pre_transition
 const FadeScene = preload("res://addons/transitions/FadeScene.tscn")
 var _root:Viewport
 var _current_scene = null
+var scene_container:Node setget _set_scene_container
 
 enum FadeType {
 	Instant,
@@ -12,9 +13,18 @@ enum FadeType {
 	Blend
 }
 
+func _set_scene_container(new_container):
+	# Allow users to specify their own scene container node.
+	# This method also sets the current scene to be the last child of the new container.
+	scene_container = new_container
+	_current_scene = scene_container.get_child(scene_container.get_child_count() - 1)
+
 func _ready():
 	_root = get_tree().root
-	_current_scene = _root.get_child(_root.get_child_count() - 1)
+	# Set the default container to be the root viewport.
+	# This maintains backwards compatability with previous versions.
+	scene_container = _root
+	_current_scene = scene_container.get_child(scene_container.get_child_count() - 1)
 
 func change_scene(new_scene:Node2D, fade_type, fade_time_seconds:float, shader_image:StreamTexture = null) -> void:
 	if new_scene == null:
@@ -112,7 +122,7 @@ func _set_scene(new_scene):
 	_current_scene.get_parent().remove_child(_current_scene)
 	_current_scene.queue_free()
 		
-	_root.add_child(new_scene)
+	scene_container.add_child(new_scene)
 
 # Necessary for those buttery-smooth jitter-free fades
 func _take_screenshot():

--- a/addons/transitions/Transitions.gd
+++ b/addons/transitions/Transitions.gd
@@ -4,7 +4,6 @@ signal pre_transition
 
 const FadeScene = preload("res://addons/transitions/FadeScene.tscn")
 var _root:Viewport
-var _current_scene = null
 var scene_container:Node setget _set_scene_container
 
 enum FadeType {
@@ -19,7 +18,7 @@ func _set_scene_container(new_container:Node):
 		push_error("Can't change scene container to null scene!")
 	scene_container = new_container
 
-func _current_scene():
+func _get_current_scene():
 	return scene_container.get_child(scene_container.get_child_count() - 1)
 
 func _ready():
@@ -119,7 +118,7 @@ func _common_post_fade(data:Array, new_scene) -> void:
 
 func _set_scene(new_scene):
 	# Dispose old scene so we don't get any camera jitters or wierdness.
-	var previous_scene = _current_scene()
+	var previous_scene = _get_current_scene()
 	scene_container.remove_child(previous_scene)
 	previous_scene.queue_free()
 	scene_container.add_child(new_scene)

--- a/addons/transitions/Transitions.gd
+++ b/addons/transitions/Transitions.gd
@@ -14,19 +14,19 @@ enum FadeType {
 }
 
 func _set_scene_container(new_container:Node):
+	# Allow users to specify their own scene container node.
 	if new_container == null:
 		push_error("Can't change scene container to null scene!")
-	# Allow users to specify their own scene container node.
-	# This method also sets the current scene to be the last child of the new container.
 	scene_container = new_container
-	_current_scene = scene_container.get_child(scene_container.get_child_count() - 1)
+
+func _current_scene():
+	return scene_container.get_child(scene_container.get_child_count() - 1)
 
 func _ready():
 	_root = get_tree().root
 	# Set the default container to be the root viewport.
 	# This maintains backwards compatability with previous versions.
 	scene_container = _root
-	_current_scene = scene_container.get_child(scene_container.get_child_count() - 1)
 
 func change_scene(new_scene:Node2D, fade_type, fade_time_seconds:float, shader_image:StreamTexture = null) -> void:
 	if new_scene == null:
@@ -115,15 +115,13 @@ func _common_wait_for_fade(data:Array, fade_type, fade_seconds:float) -> void:
 # new_scene is either Node2D or PackedScene. #herp #derp
 func _common_post_fade(data:Array, new_scene) -> void:
 	var fade_scene = data[1]
-	
 	_root.remove_child(fade_scene)
-	_current_scene = new_scene
 
 func _set_scene(new_scene):
 	# Dispose old scene so we don't get any camera jitters or wierdness.
-	_current_scene.get_parent().remove_child(_current_scene)
-	_current_scene.queue_free()
-		
+	var previous_scene = _current_scene()
+	scene_container.remove_child(previous_scene)
+	previous_scene.queue_free()
 	scene_container.add_child(new_scene)
 
 # Necessary for those buttery-smooth jitter-free fades


### PR DESCRIPTION
This PR adds another variable, the scene container node. This allows users with a workflow where they have a node that contains the current scene that is not the root viewport to still use Transitions.
The scene container defaults to be the root viewport, so anyone using the plugin doesn't need to change anything.

The root viewport is still used to create the screenshot, as this seemed to be a separate aspect of the plugin to the scene node's removal/addition.